### PR TITLE
Fixed issues on Windows. Updated plugin recs.

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,1 +1,2 @@
 printWidth: 85
+endOfLine: auto

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
-  "recommendations": ["esbenp.prettier-vscod", "dbaeumer.vscode-eslint"]
+  "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
-  "recommendations": ["ms-vscode.vscode-typescript-tslint-plugin"]
+  "recommendations": ["esbenp.prettier-vscod", "dbaeumer.vscode-eslint"]
 }

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This example is using the Zowe FTP CLI plugin as a dependency to provide FTP cap
   ```bash
   zowe profiles create zftp <profile name> -H <host> -u <user> -p <password> -P <port>
   ```
-- Clone this `vscode-extension-for-zowe-api-sample` repo in a parallel directory:
+- Clone this `vscode-extension-for-zowe-api-sample` repo:
   ```bash
-  git clone git@github.com:phaumer/vscode-extension-for-zowe-api-sample.git
+  git clone git@github.com:zowe/zowe-explorer-ftp-extension.git
   ```
 - Build the VS Code extension with
   ```bash
@@ -43,6 +43,6 @@ This example is using the Zowe FTP CLI plugin as a dependency to provide FTP cap
 
 TBD, but the rough steps would be:
 
-- Copy the file `src/ZoweExplorerAPI.ts`
+- Copy the file `src/api/ZoweExplorerAPI.ts`
 - Implement classes that implement any of the `IMvs`, `IUss`, `IJes` interfaces.
 - Implement a registration method similar to `registerFtpApi()` in `extension.ts` that queries the Zowe Explorer API and calls the registration method.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "vscode:prepublish": "npm run build && npm run lint",
     "build": "tsc -p ./",
-    "lint": "concurrently -n '_eslint_,prettier' 'eslint . --ext .ts' 'prettier --check .'",
+    "lint": "concurrently -n \"_eslint_,prettier\" \"eslint . --ext .ts\" \"prettier --check .\"",
     "pretty": "prettier --write .",
     "watch": "tsc -watch -p ./",
     "package": "vsce package"


### PR DESCRIPTION
Signed-off-by: Peter Haumer <4391934+phaumer@users.noreply.github.com>

I saw two issues on Windows:

- The one reported in #5 
- `npm run prettier` would replace all LFs with CRLFs

