### PR TITLE
Set line endings to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,1 @@
 printWidth: 85
-endOfLine: auto


### PR DESCRIPTION
To avoid problems with different line endings on different platforms, this PR sets line endings to `LF`. It follows the default prettier setting since version 2.0.0.

* `.gitattributes` tells git that it should check out text files with `LF` line endings (regardless of platform)
* `.prettier.yaml` (default value for `endOfLine` is `lf`) tells prettier that it should format files with `LF` line endings
* `.editorconfig` - _not changed in this PR_  - already specifies `end_of_line` as `nl`.

After this is merged into master, contributors on Windows should:

1. commit any work in progress
1. switch to the master branch pull the changes
1. update their working tree to match the new settings by running

```sh
git rm --cached -r .
git reset --hard
```

This will checkout their working tree with LF line endings (git does not update files on checkout if they have not changed - and line endings do not count for change).

Alternatively, cloning the repository will achieve the same thing. More details can be found in [this stackoverflow article](https://stackoverflow.com/questions/15641259/how-to-normalize-working-tree-line-endings-in-git).

Signed-off-by: Vit Gottwald <vit.gottwald@gmail.com>